### PR TITLE
Render SDP examples

### DIFF
--- a/extract-docs.sh
+++ b/extract-docs.sh
@@ -205,6 +205,11 @@ function render_examples {
         render-json.sh -n "$i" "Example ${i##*/}" >> "$HTML_EXAMPLE"
     done
 
+    for i in "$examples_dir"/*.sdp; do
+        HTML_EXAMPLE=${i%%.sdp}.html
+        render-other-code.sh -n "$i" "Example ${i##*/}" >> "$HTML_EXAMPLE"
+    done
+
     echo "Moving examples"
     mkdir -p "../$target_dir/$examples_dir"
     for i in "$examples_dir"/*.html; do

--- a/render-other-code.sh
+++ b/render-other-code.sh
@@ -23,7 +23,7 @@ else
     SHOW_LINE_NUMBERS=false
 fi
 
-WEBIDL_FILE=$1
+CODE_FILE=$1
 NAME=$2
 ALT_HREF=$3
 ALT_TEXT=$4
@@ -53,12 +53,11 @@ cat <<EOF
 <div id="json-render">
 EOF
 
-if $LINT "$WEBIDL_FILE" ; then
+if $LINT "$CODE_FILE" ; then
 
     cat <<-EOF
 <script type="text/javascript" src="codemirror/lib/codemirror.js"></script>
 <link rel="stylesheet" href="codemirror/lib/codemirror.css">
-<script src="codemirror/mode/webidl/webidl.js"></script>
 
 <style>
   .CodeMirror {
@@ -71,7 +70,7 @@ if $LINT "$WEBIDL_FILE" ; then
 <textarea id="mytextarea">
 EOF
 
-    cat "$WEBIDL_FILE"
+    cat "$CODE_FILE"
     cat <<-EOF
 </textarea>
 <script>
@@ -85,7 +84,7 @@ EOF
 
 else # Failed lint so do minimal render
     echo "<pre>"
-    cat "$WEBIDL_FILE"
+    cat "$CODE_FILE"
     echo "</pre>"
 fi
 


### PR DESCRIPTION
Adds render-other-code.sh and renders SDP examples with it.
Note that SDP and JSON examples are both indexed without their suffixes.