### PR TITLE
Fix vx.y release rewrite rule

### DIFF
--- a/make-rewrites.sh
+++ b/make-rewrites.sh
@@ -45,7 +45,7 @@ if [[ -d releases ]]; then
 }
 END {
     for (v in latest) {
-        printf("RewriteRule ^%s(.*) releases/v%s$1\n", v, latest[v])
+        printf("RewriteRule ^v%s(.*) releases/v%s$1\n", v, latest[v])
         overall_latest = latest[v]
     }
     printf("RewriteRule ^latest(.*) releases/v%s$1\n", overall_latest)


### PR DESCRIPTION
e.g. https://specs.amwa.tv/is-09/v1.0 was broken (worked without the "v") -- I've rendered that one locally with this branch and uploaded.  Also https://specs.amwa.tv/is-08/v1.0 