### PR TITLE
Don't use JsonLoader as it's no longer exposed in jsonref

### DIFF
--- a/resolve-schema.py
+++ b/resolve-schema.py
@@ -28,16 +28,14 @@ def load_resolved_schema(spec_path, file_name=None, schema_obj=None, path_prefix
     else:
         base_uri_path = "file://" + base_path
 
-    loader = jsonref.JsonLoader(cache_results=False)
-
     if file_name:
         json_file = str(Path(base_path) / file_name)
         with open(json_file, "r") as f:
-            schema = jsonref.load(f, base_uri=base_uri_path, loader=loader, jsonschema=True)
+            schema = jsonref.load(f, base_uri=base_uri_path, jsonschema=True)
     elif schema_obj:
         # Work around an exception when there's nothing to resolve using an object
         if "$ref" in schema_obj:
-            schema = jsonref.JsonRef.replace_refs(schema_obj, base_uri=base_uri_path, loader=loader, jsonschema=True)
+            schema = jsonref.JsonRef.replace_refs(schema_obj, base_uri=base_uri_path, jsonschema=True)
         else:
             schema = schema_obj
 


### PR DESCRIPTION
JsonLoader was removed in jsonref v1.0.0, giving this error:

> AttributeError: module ‘jsonref’ has no attribute ‘JsonLoader’. Did you mean: ’jsonloader

Using similar fix to https://github.com/AMWA-TV/nmos-testing/commit/545389b577b171caf40331ed71329b0c03685f5c