### PR TITLE
Don't add docs/ to index links

### DIFF
--- a/make-indexes.sh
+++ b/make-indexes.sh
@@ -62,7 +62,7 @@ function add_docs_from_markdown_list_of_links {
 
     # append index links with docs/
     perl -p -e 's~\]\(~\]\(docs/~' "$list" >> "$INDEX"
-    perl -p -e 's~\]\(~\]\(docs/~' "$list" >> "$INDEX_DOCS"
+    grep '](' "$list" >> "$INDEX_DOCS"
 }
 
 function add_numbered_doc {


### PR DESCRIPTION
Fix #52.  Tested manually on is-template e.g. https://specs.amwa.tv/is-template/branches/v1.0-dev/docs/